### PR TITLE
blink-diff version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Protractor plugin for image comparison",
   "main": "index.js",
   "dependencies": {
-    "blink-diff": "1.0.7",
+    "blink-diff": "1.0.12",
     "png-image": "1.0.1",
     "camel-case": "1.2.2"
   },

--- a/test/jasmine.spec.js
+++ b/test/jasmine.spec.js
@@ -55,6 +55,18 @@ describe('Pix-Diff', function() {
         it('should not match the page with custom matcher', function () {
             expect(browser.pixDiff.checkScreen('exampleFail', {threshold: 1})).not.toMatchScreen();
         });
+
+        it('should not crash with image not found', function () {
+            var errorThrown = false;
+            browser.pixDiff.checkScreen('imagenotexst', {threshold: 1}).then(function (result) {
+                fail('must not do a comparison.');
+            }).catch(function (error) {
+                // good
+                errorThrown = true;
+            }).then(function () {
+                expect(errorThrown).toBe(true);
+            });
+        });
     });
 
     describe('format image name', function() {

--- a/test/mocha.spec.js
+++ b/test/mocha.spec.js
@@ -56,6 +56,18 @@ describe('Pix-Diff', function() {
         it('should not match the page with custom matcher', function () {
             expect(browser.pixDiff.checkScreen('example-fail', {threshold: 1})).not.to.matchScreen();
         });
+
+        it('should not crash with image not found', function () {
+            var errorThrown = false;
+            browser.pixDiff.checkScreen('imagenotexst', {threshold: 1}).then(function (result) {
+                expect.fail();
+            }).catch(function (error) {
+                // good
+                errorThrown = true;
+            }).then(function () {
+                expect(errorThrown).to.be.true;
+            });
+        });
     });
 
     describe('format image name', function() {


### PR DESCRIPTION
Versions 1.0.7 of blink-diff references pngjs-image 0.9.3 that is buggy and crashes process when no image is found. An update of blink-diff is sufficient to get a newer version of pngjs-image.