### PR TITLE
Feature/add cucumber support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
         },
 
         jshint: {
-            all: ['index.js', 'test/**/*.spec.js'],
+            all: ['index.js', 'test/**/*.spec.js', 'test/**/*.steps.js'],
             options: {
                 jshintrc: '.jshintrc',
                 ignores: ['node_modules/', 'framework/']
@@ -24,6 +24,12 @@ module.exports = function(grunt) {
         },
 
         run: {
+            cucumber: {
+                cmd: 'node_modules/.bin/protractor',
+                args: [
+                    'test/protractorCucumber.conf.js'
+                ]
+            },
             jasmine: {
                 cmd: 'node_modules/.bin/protractor',
                 args: [
@@ -55,9 +61,10 @@ module.exports = function(grunt) {
     });
 
     //tasks
+    grunt.registerTask('cucumber', 'Run cucumber integration tests', ['clean:screens', 'run:cucumber']);
     grunt.registerTask('jasmine', 'Run Jasmine integration tests', ['clean:screens', 'run:jasmine']);
     grunt.registerTask('mocha', 'Run Mocha integration tests', ['clean:screens', 'run:mocha']);
     grunt.registerTask('build', ['jshint:all']);
     grunt.registerTask('release', ['bump']);
-    grunt.registerTask('default', ['jasmine', 'mocha']);
+    grunt.registerTask('default', ['jasmine', 'mocha', 'cucumber']);
 };

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ exports.config = {
 ```
 
 PixDiff provides two comparison methods ```checkScreen``` and ```checkRegion``` along with Jasmine ```toMatchScreen``` and Mocha ```matchScreen``` matchers. Two helper methods ```saveScreen``` and ```saveRegion``` are provided for saving images.
+PixDiff can also work with Cucumber.js. There are no comparison methods provided for Cucumber.js because Cucumber.js doesn't have its own ```expect``` methods.
 
 **Jasmine Example:**
 ```javascript
@@ -71,6 +72,53 @@ describe("Example page", function() {
             blockOut: [{x: 10, y: 132, width: 100, height: 50}]})).toMatchScreen();
     });
 });
+```
+
+**Cucumber Example:**
+```javascript
+var chai = require('chai'),
+    chaiAsPromised = require('chai-as-promised');
+
+chai.use(chaiAsPromised);
+var expect = chai.expect;
+
+function CucumberSteps() {
+    this.Given(/^I load the url$/, function () {
+        return browser.get('http://www.example.com/');
+    });
+
+    this.Then(/^Pix\-Diff should match the page$/, function () {
+        return browser.pixDiff.checkScreen('examplePage')
+            .then(function (result) {
+                return expect(result.differences).to.equal(0);
+            });
+    });
+
+    this.Then(/^Pix\-Diff should not match the page$/, function () {
+        element(By.buttonText('yes')).click();
+        return browser.pixDiff.checkScreen('examplePage')
+            .then(function (result) {
+                return expect(result.differences).to.not.equal(0);
+            });
+    });
+
+    this.Then(/^Pix\-Diff should match the title$/, function () {
+        return browser.pixDiff.checkRegion(element(By.id('title')), 'example page title')
+            .then(function (result) {
+                return expect(result.differences).to.equal(0);
+            });
+    });
+
+    this.Then(/^Pix\-Diff should match the title with blockout$/, function () {
+        return browser.pixDiff.checkRegion(element(By.id('title')), 'example page title', {
+            blockOut: [{x: 10, y: 132, width: 100, height: 50}]})
+            .then(function (result) {
+                return expect(result.differences).to.equal(0);
+            });
+    });
+}
+
+module.exports = CucumberSteps;
 ```
 
 ####PixDiff Parameters:
@@ -137,7 +185,7 @@ npm test
 
 Run all tests by framework:
 ```shell
-npm test -- jasmine/mocha
+npm test -- jasmine/mocha/cucumber
 ```
 
 ###Dependencies
@@ -155,6 +203,8 @@ npm test -- jasmine/mocha
 * [mocha](https://github.com/mochajs/mocha)
 * [chai](https://github.com/chaijs/chai)
 * [chai-as-promised](https://github.com/domenic/chai-as-promised)
+* [cucumber](https://github.com/cucumber/cucumber-js)
+* [protractor-cucumber-framework](https://github.com/mattfritz/protractor-cucumber-framework)
 
 ##License
 

--- a/index.js
+++ b/index.js
@@ -54,8 +54,10 @@ function PixDiff(options) {
         .then(function (data) {
             this.capabilities = data.capabilities;
             assert.ok(this.capabilities.browserName, 'Browser name is undefined.');
-            // Require PixDiff matchers
-            require(path.resolve(__dirname, 'framework', data.framework));
+            // Require PixDiff matchers for jasmine(2)/mocha
+            if (data.framework !== 'custom') {
+                require(path.resolve(__dirname, 'framework', data.framework));
+            }
             return browser.driver.executeScript('return window.devicePixelRatio;');
         }.bind(this))
         .then(function (ratio) {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "chai-as-promised": "^5.3.0",
+    "cucumber": "^1.2.2",
     "grunt": "^1.0.1",
     "grunt-bump": "^0.8.0",
     "grunt-cli": "^1.2.0",
@@ -19,7 +21,8 @@
     "jshint": "^2.9.2",
     "load-grunt-tasks": "^3.5.0",
     "mocha": "^2.4.5",
-    "protractor": "3.2.2"
+    "protractor": "^3.2.2",
+    "protractor-cucumber-framework": "^0.6.0"
   },
   "scripts": {
     "wd-update": "node_modules/.bin/webdriver-manager update",

--- a/test/cucumber.feature
+++ b/test/cucumber.feature
@@ -1,0 +1,25 @@
+Feature: Pix-Diff
+
+  Scenario: Method matchers save screen
+    Given I set up the matchers environment
+    Then Pix-Diff should save the screen
+
+  Scenario: Method matchers save screen region
+    Given I set up the matchers environment
+    Then Pix-Diff should save the screen region
+
+  Scenario: Method matchers match page
+    Given I set up the matchers environment
+    Then Pix-Diff should match the page
+
+  Scenario: Method matchers not match page
+    Given I set up the matchers environment
+    Then Pix-Diff should not match the page
+
+  Scenario: Method matchers image not found
+    Given I set up the matchers environment
+    Then Pix-Diff should not crash with image not found
+
+  Scenario: Format image name
+    Given I set up the format image name environment
+    Then Pix-Diff should save screen with formatted basename

--- a/test/cucumber.steps.js
+++ b/test/cucumber.steps.js
@@ -1,0 +1,94 @@
+'use strict';
+
+var BlinkDiff = require('blink-diff'),
+    chai = require('chai'),
+    chaiAsPromised = require('chai-as-promised'),
+    fs = require('fs'),
+    PixDiff = require('../index');
+
+chai.use(chaiAsPromised);
+var expect = chai.expect;
+
+function CucumberSteps() {
+
+    this.Given(/^I set up the matchers environment$/, function () {
+        browser.get(browser.baseUrl);
+
+        browser.pixDiff = new PixDiff({
+            basePath: 'test/screenshots',
+            width: 800,
+            height: 600
+        });
+    });
+
+    this.Given(/^I set up the format image name environment$/, function () {
+        browser.get(browser.baseUrl);
+
+        browser.pixDiff = new PixDiff({
+            basePath: 'test/screenshots',
+            width: 800,
+            height: 600,
+            formatImageOptions: {'env': 'TEST'},
+            formatImageName: '{env}_{tag}_{browserName}_{width}-{height}'
+        });
+    });
+
+    this.Then(/^Pix\-Diff should save the screen$/, function () {
+        var tagName = 'examplePage';
+
+        return browser.pixDiff.saveScreen(tagName)
+            .then(function () {
+                return expect(fs.statSync(__dirname + '/screenshots/' + tagName + '-chrome-800x600.png').isFile()).to.equal(true);
+            });
+    });
+
+    this.Then(/^Pix\-Diff should save the screen region$/, function () {
+        var tagName = 'examplePageRegion';
+
+        return browser.pixDiff.saveRegion(element(by.css('div h1')), tagName)
+            .then(function () {
+                return expect(fs.statSync(__dirname + '/screenshots/' + tagName + '-chrome-800x600.png').isFile()).to.equal(true);
+            });
+    });
+
+    this.Then(/^Pix\-Diff should match the page$/, function () {
+        return browser.pixDiff.checkScreen('examplePage')
+            .then(function (result) {
+                return expect(result.code).to.equal(BlinkDiff.RESULT_IDENTICAL);
+            });
+    });
+
+    this.Then(/^Pix\-Diff should not match the page$/, function () {
+        return browser.pixDiff.checkScreen('example-fail', {threshold: 1})
+            .then(function (result) {
+                return expect(result.code).to.equal(BlinkDiff.RESULT_DIFFERENT);
+            });
+    });
+
+    this.Then(/^Pix\-Diff should not crash with image not found$/, function () {
+        var errorThrown = false;
+
+        return browser.pixDiff.checkScreen('imagenotexst', {threshold: 1})
+            .then(function () {
+                fail('must not do a comparison.');
+            })
+            .catch(function () {
+                // good
+                errorThrown = true;
+            })
+            .then(function () {
+                return expect(errorThrown).to.equal(true);
+            });
+    });
+
+    this.Then(/^Pix\-Diff should save screen with formatted basename$/, function () {
+        var tagName = 'customName';
+
+        return browser.pixDiff.saveScreen(tagName)
+            .then(function () {
+                return expect(fs.statSync(__dirname + '/screenshots/TEST_' + tagName + '_chrome_800-600.png').isFile()).to.equal(true);
+            });
+    });
+}
+
+module.exports = CucumberSteps;

--- a/test/jasmine.spec.js
+++ b/test/jasmine.spec.js
@@ -58,9 +58,9 @@ describe('Pix-Diff', function() {
 
         it('should not crash with image not found', function () {
             var errorThrown = false;
-            browser.pixDiff.checkScreen('imagenotexst', {threshold: 1}).then(function (result) {
+            browser.pixDiff.checkScreen('imagenotexst', {threshold: 1}).then(function () {
                 fail('must not do a comparison.');
-            }).catch(function (error) {
+            }).catch(function () {
                 // good
                 errorThrown = true;
             }).then(function () {

--- a/test/mocha.spec.js
+++ b/test/mocha.spec.js
@@ -59,9 +59,9 @@ describe('Pix-Diff', function() {
 
         it('should not crash with image not found', function () {
             var errorThrown = false;
-            browser.pixDiff.checkScreen('imagenotexst', {threshold: 1}).then(function (result) {
+            browser.pixDiff.checkScreen('imagenotexst', {threshold: 1}).then(function () {
                 expect.fail();
-            }).catch(function (error) {
+            }).catch(function () {
                 // good
                 errorThrown = true;
             }).then(function () {

--- a/test/protractorCucumber.conf.js
+++ b/test/protractorCucumber.conf.js
@@ -1,0 +1,31 @@
+'use strict';
+
+exports.config = {
+
+    baseUrl: 'http://www.example.com',
+
+    framework: 'custom',
+
+    frameworkPath: require.resolve('protractor-cucumber-framework'),
+
+    cucumberOpts: {
+        format: 'pretty',
+        require: ['cucumber.steps.js']
+    },
+
+    specs: ['cucumber.feature'],
+
+    capabilities: {
+        browserName: 'chrome',
+        chromeOptions: {
+            args: ['--no-sandbox']
+        }
+    },
+
+    directConnect: true,
+
+    onPrepare: function () {
+        browser.ignoreSynchronization = true;
+    }
+
+};


### PR DESCRIPTION
This is a PR for Cucumber.js support as raised in [#18](https://github.com/koola/pix-diff/issues/18). 
This also fixes jshint errors in jasmine / mocha specs.

I've chosen not to provide a comparison methods for Cucumber.js because `chai` and `chai-as-promised` need to be required in the `step`-files to be able to use `expect`. The user can write its own method by following the Chai Guide