### PR TITLE
Fix broken Firefox DevicePixelRation and fix and save/checkRegion after scroll

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
   - "stable"
 
 addons:
+  firefox: "latest"
   apt:
     sources:
       - google-chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ node_js:
   - "stable"
 
 addons:
-  firefox: "latest"
   apt:
     sources:
       - google-chrome

--- a/index.js
+++ b/index.js
@@ -59,8 +59,9 @@ function PixDiff(options) {
             if (data.framework !== 'custom') {
                 require(path.resolve(__dirname, 'framework', data.framework));
             }
-            if (!this.isFirefox())
+            if (!this.isFirefox()) {
                 return this.getPixelDeviceRatio();
+            }
         }.bind(this))
         .then(function (ratio) {
             this.devicePixelRatio = ratio;
@@ -165,8 +166,9 @@ PixDiff.prototype = {
     getElementPosition: function (element) {
         // Firefox creates screenshots in a different way. Although it could be taken on a Retina screen,
         // the screenshot is returned in its original (no factor x is used) dimensions
-        if (this.isFirefox() || this.isInternetExplorer())
+        if (this.isFirefox() || this.isInternetExplorer()) {
             return this.getElementPositionTopPage(element);
+        }
 
         return this.getElementPositionTopWindow(element);
     },


### PR DESCRIPTION
This is a PR for the "bug" in issue [20](https://github.com/koola/pix-diff/issues/20)