### PR TITLE
Extend formatImageName with 'name' and 'logName'

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ The naming convention can be customized by passing the parameter ```formatImageN
 The following variables can be passed to format the string
 * ```browserName``` The browser name property from the capabilities
 * ```dpr``` The device pixel ratio
+* ```name``` The name from capabilities
+* ```logName``` The logName from capabilities
+* ```deviceName``` The deviceName from capabilities
 
 Images specified via name in the spec method will be selected according to the browsers current resolution. That is to say that multiple images can share the same name differentated by resolution.
 

--- a/index.js
+++ b/index.js
@@ -60,6 +60,8 @@ function PixDiff(options) {
         this.browserName = camelCase(_.capabilities.browserName);
         this.platformName = _.capabilities.platformName ? camelCase(_.capabilities.platformName) : '';
         this.deviceName = _.capabilities.deviceName ? camelCase(_.capabilities.deviceName) : '';
+        this.name = _.capabilities.name ? _.capabilities.name : '';
+        this.logName = _.capabilities.logName ? _.capabilities.logName : '';
 
         if (_.framework !== 'custom') {
             // Require PixDiff matchers for jasmine(2)/mocha
@@ -120,6 +122,8 @@ PixDiff.prototype = {
             'tag': camelCase(description),
             'browserName': this.browserName,
             'deviceName': this.deviceName,
+            'name': this.name,
+            'logName': this.logName,
             'dpr': this.devicePixelRatio,
             'width': this.width,
             'height': this.height


### PR DESCRIPTION
I needed a way to name my images on more than just the browser.  I wanted to name them based upon the "name" of the capability so I could have multiple capabilities using the same browser but with different settings. (OS, version, etc)

This change adds support for using the `name` and `logName` that are standard in protractor capability configurations.  (https://github.com/angular/protractor/blob/master/lib/config.ts#L228)

