### PR TITLE
Bugfix: wrong JSdocs for constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,8 @@ var BlinkDiff = require('blink-diff'),
  * @class PixDiff
  * @param {object} options
  * @param {string} options.basePath Path to screenshots folder
- * @param {string} options.width Width of browser
- * @param {string} options.height Height of browser
+ * @param {int} options.width Width of browser
+ * @param {int} options.height Height of browser
  * @param {boolean} options.autoResize Automatically resize the browser
  * @param {string} options.formatImageOptions Custom variables for Image Name
  * @param {string} options.formatImageName Custom format image name


### PR DESCRIPTION
Width and height must be integers, else you will get the error: java.lang.String cannot be cast to java.lang.Number